### PR TITLE
Add ASCII art Smurf to hub page

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,4 @@
-import Button from './Button';
-
 const Hero = () => {
-  const executeScroll = (offsetTop: number) => window.scrollTo(0, offsetTop);
   return (
     <section className="min-h-[600px] w-full bg-hero bg-cover bg-right-top bg-no-repeat md:min-h-[1200px] md:bg-right-top">
       <div className="mx-auto flex px-6 pt-12 text-left md:container md:bg-transparent md:pt-48">

--- a/src/components/SmurfAscii.tsx
+++ b/src/components/SmurfAscii.tsx
@@ -1,26 +1,33 @@
-const smurfArt = String.raw`
-        .-""""-.
-      .'  _  _  '.
-     /   (o)(o)   \
-    |       __      |
-    |    .-'  '-.   |
-     \  /  .--.  \ /
-      '._\ '--' /_.'
-        /'-.  .-'\
-       /    \/    \
-      |  .-====-.  |
-      |  |  ||  |  |
-      |  |__||__|  |
-       \   /  \   /
-        '-'    '-'
-         little smurf
-`;
+const smurfRows = [
+  { text: '             _____________', className: 'text-brandRed' },
+  { text: "         .-''             ``-.", className: 'text-brandRed' },
+  { text: '       .\'       .-""""-.      `.', className: 'text-brandRed' },
+  { text: "      /       .'        `.       \\", className: 'text-brandRed' },
+  { text: '     /       /            \\       \\', className: 'text-brandRed' },
+  { text: '    |       /    .----.    \\       |', className: 'text-brandRed' },
+  { text: '    |      |    / .--. \\    |      |', className: 'text-brandRed' },
+  { text: '     \\     |   /_/    \\_\\   |     /', className: 'text-brandRed' },
+  { text: "      '.   |    _  __  _    |   .'", className: 'text-brandBlue' },
+  { text: "        '-.|   (o)(o)      |.-'", className: 'text-brandBlue' },
+  { text: '           |      __        |', className: 'text-brandBlue' },
+  { text: "       ____\\    '.__.'    /____", className: 'text-white' },
+  { text: "    .-'     '-.        .-'     '-.", className: 'text-white' },
+  { text: "   /   .--.    '------'    .--.   \\", className: 'text-white' },
+  { text: '  |   /    \\    .-""-.    /    \\   |', className: 'text-white' },
+  { text: "   \\  \\_.-' '--'      '--' '-._/  /", className: 'text-white' },
+  { text: "    '-.        .------.        .-'", className: 'text-brandBlue' },
+  { text: '       \\      /  .--.  \\      /', className: 'text-brandBlue' },
+  { text: '        |    |  /    \\  |    |', className: 'text-brandBlue' },
+  { text: '        |    |  \\____/  |    |', className: 'text-brandRed' },
+  { text: '       /____/          \\____\\', className: 'text-brandRed' },
+  { text: '      (_/                  \\_)', className: 'text-brandRed' },
+];
 
 const SmurfAscii = () => {
   return (
     <section
       aria-labelledby="smurf-ascii-heading"
-      className="mx-auto w-full max-w-full overflow-hidden px-6 py-12 text-brandGreen md:container md:py-20"
+      className="mx-auto w-full max-w-full overflow-hidden px-6 py-12 md:container md:py-20"
     >
       <h2 id="smurf-ascii-heading" className="sr-only">
         ASCII art Smurf
@@ -30,7 +37,11 @@ const SmurfAscii = () => {
           aria-hidden="true"
           className="max-w-full overflow-x-auto whitespace-pre font-mono text-[clamp(0.55rem,2.4vw,1rem)] leading-[1.05] tracking-normal"
         >
-          {smurfArt}
+          {smurfRows.map((row) => (
+            <span key={row.text} className={`block ${row.className}`}>
+              {row.text}
+            </span>
+          ))}
         </pre>
       </div>
     </section>

--- a/src/components/SmurfAscii.tsx
+++ b/src/components/SmurfAscii.tsx
@@ -1,0 +1,40 @@
+const smurfArt = String.raw`
+        .-""""-.
+      .'  _  _  '.
+     /   (o)(o)   \
+    |       __      |
+    |    .-'  '-.   |
+     \  /  .--.  \ /
+      '._\ '--' /_.'
+        /'-.  .-'\
+       /    \/    \
+      |  .-====-.  |
+      |  |  ||  |  |
+      |  |__||__|  |
+       \   /  \   /
+        '-'    '-'
+         little smurf
+`;
+
+const SmurfAscii = () => {
+  return (
+    <section
+      aria-labelledby="smurf-ascii-heading"
+      className="mx-auto w-full max-w-full overflow-hidden px-6 py-12 text-brandGreen md:container md:py-20"
+    >
+      <h2 id="smurf-ascii-heading" className="sr-only">
+        ASCII art Smurf
+      </h2>
+      <div className="flex justify-center">
+        <pre
+          aria-hidden="true"
+          className="max-w-full overflow-x-auto whitespace-pre font-mono text-[clamp(0.55rem,2.4vw,1rem)] leading-[1.05] tracking-normal"
+        >
+          {smurfArt}
+        </pre>
+      </div>
+    </section>
+  );
+};
+
+export default SmurfAscii;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import Hero from 'components/Hero';
 import PublicGoods from 'components/PublicGoods';
+import SmurfAscii from 'components/SmurfAscii';
 
 const Home = () => {
   return (
     <main>
       <Hero />
+      <SmurfAscii />
       <PublicGoods />
     </main>
   );


### PR DESCRIPTION
## Summary
- Add a responsive ASCII Smurf section to the home/hub page
- Keep the ASCII art in a focused component with hidden accessible heading and decorative preformatted art
- Remove an existing unused Hero import/function so lint stays clean

## Validation
- npm run lint
- npm run build
- NODE_ENV=test npm test -- --runInBand

Notes: plain npm test fails in this runtime because React resolves to the production build unless NODE_ENV=test is set explicitly.